### PR TITLE
Revert "Fixed authRequired Middleware & Got API for Admin Dashboard Working "

### DIFF
--- a/api/allIncidents/adminIncidentsRouter.js
+++ b/api/allIncidents/adminIncidentsRouter.js
@@ -27,7 +27,6 @@ router.use(authRequired);
 router.get('/incidents', async (req, res, next) => {
   Incidents.getAllPendingIncidents()
     .then((incidents) => {
-      console.log('Admin Dashboard Incidents Router RES', res);
       res.status(200).json(incidents);
     })
     .catch(next);

--- a/api/middleware/authRequired.js
+++ b/api/middleware/authRequired.js
@@ -7,22 +7,18 @@ const oktaJwtVerifier = new OktaJwtVerifier(oktaVerifierConfig.config);
  * A simple middleware that asserts valid access tokens and sends 401 responses
  * if the token is not present or fails validation.
  */
-const authRequired = (req, res, next) => {
-  const authHeader = req.headers.authorization || '';
-  const match = authHeader.match(/Bearer (.+)/);
-  if (!match) {
-    throw new Error('No idToken');
+const authRequired = async (req, res, next) => {
+  try {
+    const authHeader = req.headers.authorization || '';
+    oktaJwtVerifier
+      .verifyAccessToken(authHeader, oktaVerifierConfig.expectedAudience)
+      .then(async () => {
+        next();
+      })
+      .catch(next);
+  } catch (err) {
+    next(createError(401, err.message));
   }
-  const idToken = match[1];
-  // eslint-disable-next-line prettier/prettier
-  oktaJwtVerifier
-    .verifyAccessToken(idToken, oktaVerifierConfig.expectedAudience)
-    .then(() => {
-      next();
-    })
-    .catch((err) => {
-      next(createError(401, err.message));
-    });
 };
 
 module.exports = authRequired;


### PR DESCRIPTION
This PR reverts Lambda-School-Labs/human-rights-first-police-be-a#87, which introduced new bugs where cases couldn't be loaded in-app. Currently, the fixes to the AuthHeader middleware seems to be stopping the front-end from being able to pull in and display approved or unapproved cases.